### PR TITLE
Link pending transactions to confirm screen.

### DIFF
--- a/app/popup.html
+++ b/app/popup.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html>
+<html style="width:350px; height:600px;">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
     <title>MetaMask Plugin</title>
   </head>
-  <body style="width:350px; height:500px;">
+  <body style="width:350px; height:600px;">
     <div id="app-content"></div>
     <script src="./scripts/popup.js" type="text/javascript" charset="utf-8"></script>
   </body>

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -83,6 +83,8 @@ var actions = {
   hideWarning: hideWarning,
   // accounts screen
   SET_SELECTED_ACCOUNT: 'SET_SELECTED_ACCOUNT',
+  SET_SELECTED_TOKEN: 'SET_SELECTED_TOKEN',
+  setSelectedToken,
   SHOW_ACCOUNT_DETAIL: 'SHOW_ACCOUNT_DETAIL',
   SHOW_ACCOUNTS_PAGE: 'SHOW_ACCOUNTS_PAGE',
   SHOW_CONF_TX_PAGE: 'SHOW_CONF_TX_PAGE',
@@ -583,6 +585,13 @@ function lockMetamask () {
 function setCurrentAccountTab (newTabName) {
   log.debug(`background.setCurrentAccountTab: ${newTabName}`)
   return callBackgroundThenUpdateNoSpinner(background.setCurrentAccountTab, newTabName)
+}
+
+function setSelectedToken (tokenAddress) {
+  return {
+    type: actions.SET_SELECTED_TOKEN,
+    value: tokenAddress || null,
+  }
 }
 
 function showAccountDetail (address) {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -421,7 +421,7 @@ function signTx (txData) {
       if (err) return dispatch(actions.displayWarning(err.message))
       dispatch(actions.hideWarning())
     })
-    dispatch(actions.showConfTxPage())
+    dispatch(actions.showConfTxPage({}))
   }
 }
 
@@ -626,10 +626,11 @@ function showAccountsPage () {
   }
 }
 
-function showConfTxPage (transForward = true) {
+function showConfTxPage ({transForward = true, id}) {
   return {
     type: actions.SHOW_CONF_TX_PAGE,
-    transForward: transForward,
+    transForward,
+    id,
   }
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -95,6 +95,8 @@ var actions = {
   // account detail screen
   SHOW_SEND_PAGE: 'SHOW_SEND_PAGE',
   showSendPage: showSendPage,
+  SHOW_SEND_TOKEN_PAGE: 'SHOW_SEND_TOKEN_PAGE',
+  showSendTokenPage,
   ADD_TO_ADDRESS_BOOK: 'ADD_TO_ADDRESS_BOOK',
   addToAddressBook: addToAddressBook,
   REQUEST_ACCOUNT_EXPORT: 'REQUEST_ACCOUNT_EXPORT',
@@ -925,6 +927,12 @@ function saveAccountLabel (account, label) {
 function showSendPage () {
   return {
     type: actions.SHOW_SEND_PAGE,
+  }
+}
+
+function showSendTokenPage () {
+  return {
+    type: actions.SHOW_SEND_TOKEN_PAGE,
   }
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -417,7 +417,7 @@ function signTx (txData) {
       if (err) return dispatch(actions.displayWarning(err.message))
       dispatch(actions.hideWarning())
     })
-    dispatch(this.showConfTxPage())
+    dispatch(actions.showConfTxPage())
   }
 }
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -9,6 +9,7 @@ const NewKeyChainScreen = require('./new-keychain')
 // accounts
 const MainContainer = require('./main-container')
 const SendTransactionScreen = require('./send')
+const SendTokenScreen = require('./components/send-token')
 const ConfirmTxScreen = require('./conf-tx')
 // notice
 const NoticeScreen = require('./components/notice')
@@ -326,6 +327,10 @@ App.prototype.renderPrimary = function () {
     case 'sendTransaction':
       log.debug('rendering send tx screen')
       return h(SendTransactionScreen, {key: 'send-transaction'})
+
+    case 'sendToken':
+      log.debug('rendering send token screen')
+      return h(SendTokenScreen, {key: 'sendToken'})
 
     case 'newKeychain':
       log.debug('rendering new keychain screen')

--- a/ui/app/components/balance-component.js
+++ b/ui/app/components/balance-component.js
@@ -3,6 +3,7 @@ const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const TokenBalance = require('./token-balance')
+const Identicon = require('./identicon')
 
 const { formatBalance, generateBalanceObject } = require('../util')
 
@@ -10,11 +11,13 @@ module.exports = connect(mapStateToProps)(BalanceComponent)
 
 function mapStateToProps (state) {
   const accounts = state.metamask.accounts
+  const network = state.metamask.network
   const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
   const account = accounts[selectedAddress]
 
   return {
     account,
+    network,
     conversionRate: state.metamask.conversionRate,
     currentCurrency: state.metamask.currentCurrency,
   }
@@ -27,15 +30,19 @@ function BalanceComponent () {
 
 BalanceComponent.prototype.render = function () {
   const props = this.props
-  // const { balanceValue } = props
-  const { token } = props
+  const { token, network } = props
 
   return h('div.balance-container', {}, [
 
     // TODO: balance icon needs to be passed in
-    h('img.balance-icon', {
-      src: '../images/eth_logo.svg',
-      style: {},
+    // h('img.balance-icon', {
+    //   src: '../images/eth_logo.svg',
+    //   style: {},
+    // }),
+    h(Identicon, {
+      diameter: 45,
+      address: token && token.address,
+      network,
     }),
 
     token ? this.renderTokenBalance() : this.renderBalance(),

--- a/ui/app/components/balance-component.js
+++ b/ui/app/components/balance-component.js
@@ -2,13 +2,19 @@ const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const TokenBalance = require('./token-balance')
 
 const { formatBalance, generateBalanceObject } = require('../util')
 
 module.exports = connect(mapStateToProps)(BalanceComponent)
 
 function mapStateToProps (state) {
+  const accounts = state.metamask.accounts
+  const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
+  const account = accounts[selectedAddress]
+
   return {
+    account,
     conversionRate: state.metamask.conversionRate,
     currentCurrency: state.metamask.currentCurrency,
   }
@@ -21,9 +27,8 @@ function BalanceComponent () {
 
 BalanceComponent.prototype.render = function () {
   const props = this.props
-  const { balanceValue } = props
-  const needsParse = 'needsParse' in props ? props.needsParse : true
-  const formattedBalance = balanceValue ? formatBalance(balanceValue, 6, needsParse) : '...'
+  // const { balanceValue } = props
+  const { token } = props
 
   return h('div.balance-container', {}, [
 
@@ -33,13 +38,24 @@ BalanceComponent.prototype.render = function () {
       style: {},
     }),
 
-    this.renderBalance(formattedBalance),
+    token ? this.renderTokenBalance() : this.renderBalance(),
   ])
 }
 
-BalanceComponent.prototype.renderBalance = function (formattedBalance) {
+BalanceComponent.prototype.renderTokenBalance = function () {
+  const { token } = this.props
+
+  return h('div.flex-column.balance-display', [
+    h('div.token-amount', [ h(TokenBalance, { token }) ]),
+  ])
+}
+
+BalanceComponent.prototype.renderBalance = function () {
   const props = this.props
-  const { shorten } = props
+  const { shorten, account } = props
+  const balanceValue = account && account.balance
+  const needsParse = 'needsParse' in props ? props.needsParse : true
+  const formattedBalance = balanceValue ? formatBalance(balanceValue, 6, needsParse) : '...'
   const showFiat = 'showFiat' in props ? props.showFiat : true
 
   if (formattedBalance === 'None' || formattedBalance === '...') {

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -245,7 +245,7 @@ BuyButtonSubview.prototype.navigateTo = function (url) {
 
 BuyButtonSubview.prototype.backButtonContext = function () {
   if (this.props.context === 'confTx') {
-    this.props.dispatch(actions.showConfTxPage(false))
+    this.props.dispatch(actions.showConfTxPage({transForward: false}))
   } else {
     this.props.dispatch(actions.goHome())
   }

--- a/ui/app/components/identicon.js
+++ b/ui/app/components/identicon.js
@@ -18,9 +18,11 @@ function IdenticonComponent () {
 
 IdenticonComponent.prototype.render = function () {
   var props = this.props
+  const { className = '' } = props
   var diameter = props.diameter || this.defaultDiameter
   return (
-    h('div.identicon', {
+    h('div', {
+      className: `${className} identicon`,
       key: 'identicon-' + this.props.address,
       style: {
         display: 'flex',

--- a/ui/app/components/identicon.js
+++ b/ui/app/components/identicon.js
@@ -18,23 +18,35 @@ function IdenticonComponent () {
 
 IdenticonComponent.prototype.render = function () {
   var props = this.props
-  const { className = '' } = props
+  const { className = '', address } = props
   var diameter = props.diameter || this.defaultDiameter
-  return (
-    h('div', {
-      className: `${className} identicon`,
-      key: 'identicon-' + this.props.address,
-      style: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: diameter,
-        width: diameter,
-        borderRadius: diameter / 2,
-        overflow: 'hidden',
-      },
-    })
-  )
+
+  return address
+    ? (
+      h('div', {
+        className: `${className} identicon`,
+        key: 'identicon-' + address,
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: diameter,
+          width: diameter,
+          borderRadius: diameter / 2,
+          overflow: 'hidden',
+        },
+      })
+    )
+    : (
+      h('img.balance-icon', {
+        src: '../images/eth_logo.svg',
+        style: {
+          height: diameter,
+          width: diameter,
+          borderRadius: diameter / 2,
+        },
+      })
+    )
 }
 
 IdenticonComponent.prototype.componentDidMount = function () {

--- a/ui/app/components/send-token/index.js
+++ b/ui/app/components/send-token/index.js
@@ -1,0 +1,213 @@
+const Component = require('react').Component
+const connect = require('react-redux').connect
+const h = require('react-hyperscript')
+const ethUtil = require('ethereumjs-util')
+const inherits = require('util').inherits
+const actions = require('../../actions')
+const selectors = require('../../selectors')
+
+// const BalanceComponent = require('./balance-component')
+const Identicon = require('../identicon')
+const TokenBalance = require('../token-balance')
+const CurrencyToggle = require('../send/currency-toggle')
+const GasTooltip = require('../send/gas-tooltip')
+const GasFeeDisplay = require('../send/gas-fee-display')
+
+
+module.exports = connect(mapStateToProps, mapDispatchToProps)(SendTokenScreen)
+
+function mapStateToProps (state) {
+  // const sidebarOpen = state.appState.sidebarOpen
+
+  const identities = state.metamask.identities
+  const addressBook = state.metamask.addressBook
+  const conversionRate = state.metamask.conversionRate
+  const currentBlockGasLimit = state.metamask.currentBlockGasLimit
+  // const accounts = state.metamask.accounts
+  // const network = state.metamask.network
+  const selectedTokenAddress = state.metamask.selectedTokenAddress
+  // const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
+  // const checksumAddress = selectedAddress && ethUtil.toChecksumAddress(selectedAddress)
+  // const identity = identities[selectedAddress]
+
+  return {
+    // sidebarOpen,
+    // selectedAddress,
+    // checksumAddress,
+    selectedTokenAddress,
+    identities,
+    addressBook,
+    conversionRate,
+    currentBlockGasLimit,
+    selectedToken: selectors.getSelectedToken(state),
+    // selectedToken: selectors.getSelectedToken(state),
+    // identity,
+    // network,
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    // showSidebar: () => { dispatch(actions.showSidebar()) },
+    // hideSidebar: () => { dispatch(actions.hideSidebar()) },
+    // showModal: (payload) => { dispatch(actions.showModal(payload)) },
+    // showSendPage: () => { dispatch(actions.showSendPage()) },
+    // showSendTokenPage: () => { dispatch(actions.showSendTokenPage()) },
+  }
+}
+
+inherits(SendTokenScreen, Component)
+function SendTokenScreen () {
+  Component.call(this)
+  this.state = {
+    to: '',
+    selectedCurrency: 'USD',
+    isGasTooltipOpen: false,
+    gasPrice: '0x5d21dba00',
+    gasLimit: '0x7b0d',
+  }
+}
+
+SendTokenScreen.prototype.renderToAddressInput = function () {
+  const {
+    identities,
+    addressBook,
+  } = this.props
+
+  const {
+    to,
+  } = this.state
+
+  return h('div.send-screen-input-wrapper', {}, [
+    h('div', ['To:']),
+    h('input.large-input.send-screen-input', {
+      name: 'address',
+      list: 'addresses',
+      placeholder: 'Address',
+      value: to,
+      onChange: e => this.setState({ to: e.target.value }),
+    }),
+    h('datalist#addresses', [
+      // Corresponds to the addresses owned.
+      Object.entries(identities).map(([key, { address, name }]) => {
+        return h('option', {
+          value: address,
+          label: name,
+          key: address,
+        })
+      }),
+      addressBook.map(({ address, name }) => {
+        return h('option', {
+          value: address,
+          label: name,
+          key: address,
+        })
+      }),
+    ]),
+  ])
+}
+
+SendTokenScreen.prototype.renderAmountInput = function () {
+  const {
+    selectedCurrency,
+  } = this.state
+
+  const {
+    selectedToken: {symbol},
+  } = this.props
+
+  return h('div.send-screen-input-wrapper', {}, [
+    h('div.send-screen-amount-labels', [
+      h('span', ['Amount']),
+      h(CurrencyToggle, {
+        selectedCurrency,
+        onClick: currency => this.setState({ selectedCurrency: currency }),
+      }),
+    ]),
+    h('input.large-input.send-screen-input', {
+      placeholder: `0 ${symbol}`,
+      type: 'number',
+      onChange: e => this.setState({ amount: e.target.value }),
+    }),
+  ])
+}
+
+SendTokenScreen.prototype.renderGasInput = function () {
+  const {
+    isGasTooltipOpen,
+    gasPrice,
+    gasLimit,
+    selectedCurrency,
+  } = this.state
+
+  const {
+    conversionRate,
+    currentBlockGasLimit,
+  } = this.props
+
+  return h('div.send-screen-input-wrapper', [
+    isGasTooltipOpen && h(GasTooltip, {
+      className: 'send-tooltip',
+      gasPrice,
+      gasLimit,
+      onClose: () => this.setState({ isGasTooltipOpen: false }),
+      onFeeChange: ({ gasLimit, gasPrice }) => {
+        this.setState({ gasLimit, gasPrice })
+      },
+    }),
+
+    h('div.send-screen-gas-labels', {}, [
+      h('span', [ h('i.fa.fa-bolt'), 'Gas fee:']),
+      h('span', ['What\'s this?']),
+    ]),
+    h('div.large-input.send-screen-gas-input', [
+      h(GasFeeDisplay, {
+        conversionRate,
+        gasPrice,
+        currentCurrency: selectedCurrency,
+        gas: gasLimit,
+        blockGasLimit: currentBlockGasLimit,
+      }),
+      h(
+        'div.send-screen-gas-input-customize',
+        { onClick: () => this.setState({ isGasTooltipOpen: !isGasTooltipOpen }) },
+        ['Customize']
+      ),
+    ]),
+  ])
+}
+
+SendTokenScreen.prototype.renderMemoInput = function () {
+  return h('div.send-screen-input-wrapper', {}, [
+    h('div', {}, ['Transaction memo (optional)']),
+    h(
+      'input.large-input.send-screen-input',
+      { onChange: e => this.setState({ memo: e.target.value }) }
+    ),
+  ])
+}
+
+SendTokenScreen.prototype.render = function () {
+  const {
+    selectedTokenAddress,
+    selectedToken,
+  } = this.props
+
+  return h('div.send-token', [
+    h(Identicon, {
+      diameter: 75,
+      address: selectedTokenAddress,
+    }),
+    h('div.send-token__title', ['Send Tokens']),
+    h('div.send-token__description', ['Send Tokens to anyone with an Ethereum account']),
+    h('div.send-token__balance-text', ['Your Token Balance is:']),
+    h('div.send-token__token-balance', [
+      h(TokenBalance, { token: selectedToken, balanceOnly: true }),
+    ]),
+    h('div.send-token__token-symbol', [selectedToken.symbol]),
+    this.renderToAddressInput(),
+    this.renderAmountInput(),
+    this.renderGasInput(),
+    this.renderMemoInput(),
+  ])
+}

--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -93,8 +93,10 @@ TokenBalance.prototype.componentDidUpdate = function (nextProps) {
 
 TokenBalance.prototype.updateBalance = function (tokens = []) {
   const [{ string, symbol }] = tokens
+  const { balanceOnly } = this.props
+
   this.setState({
-    balance: `${string} ${symbol}`,
+    balance: balanceOnly ? string : `${string} ${symbol}`,
     isLoading: false,
   })
 }

--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -90,9 +90,9 @@ TokenBalance.prototype.componentDidUpdate = function (nextProps) {
 }
 
 TokenBalance.prototype.updateBalance = function (tokens = []) {
-  const [{ string }] = tokens
+  const [{ string, symbol }] = tokens
   this.setState({
-    balance: string,
+    balance: `${string} ${symbol}`,
     isLoading: false,
   })
 }

--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -77,13 +77,15 @@ TokenBalance.prototype.createFreshTokenTracker = function () {
 TokenBalance.prototype.componentDidUpdate = function (nextProps) {
   const {
     userAddress: oldAddress,
+    token: { address: oldTokenAddress },
   } = this.props
   const {
     userAddress: newAddress,
+    token: { address: newTokenAddress },
   } = nextProps
 
-  if (!oldAddress || !newAddress) return
-  if (oldAddress === newAddress) return
+  if ((!oldAddress || !newAddress) && (!oldTokenAddress || !newTokenAddress)) return
+  if ((oldAddress === newAddress) && (oldTokenAddress === newTokenAddress)) return
 
   this.setState({ isLoading: true })
   this.createFreshTokenTracker()

--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -1,0 +1,104 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const TokenTracker = require('eth-token-tracker')
+const connect = require('react-redux').connect
+const selectors = require('../selectors')
+
+function mapStateToProps (state) {
+  return {
+    userAddress: selectors.getSelectedAddress(state),
+  }
+}
+
+module.exports = connect(mapStateToProps)(TokenBalance)
+
+
+inherits(TokenBalance, Component)
+function TokenBalance () {
+  this.state = {
+    balance: '',
+    isLoading: true,
+    error: null,
+  }
+  Component.call(this)
+}
+
+TokenBalance.prototype.render = function () {
+  const state = this.state
+  const { balance, isLoading } = state
+
+  return isLoading
+    ? h('span', '')
+    : h('span', balance)
+}
+
+TokenBalance.prototype.componentDidMount = function () {
+  this.createFreshTokenTracker()
+}
+
+TokenBalance.prototype.createFreshTokenTracker = function () {
+  if (this.tracker) {
+    // Clean up old trackers when refreshing:
+    this.tracker.stop()
+    this.tracker.removeListener('update', this.balanceUpdater)
+    this.tracker.removeListener('error', this.showError)
+  }
+
+  if (!global.ethereumProvider) return
+  const { userAddress, token } = this.props
+
+  this.tracker = new TokenTracker({
+    userAddress,
+    provider: global.ethereumProvider,
+    tokens: [token],
+    pollingInterval: 8000,
+  })
+
+
+  // Set up listener instances for cleaning up
+  this.balanceUpdater = this.updateBalance.bind(this)
+  this.showError = error => {
+    this.setState({ error, isLoading: false })
+  }
+  this.tracker.on('update', this.balanceUpdater)
+  this.tracker.on('error', this.showError)
+
+  this.tracker.updateBalances()
+    .then(() => {
+      this.updateBalance(this.tracker.serialize())
+    })
+    .catch((reason) => {
+      log.error(`Problem updating balances`, reason)
+      this.setState({ isLoading: false })
+    })
+}
+
+TokenBalance.prototype.componentDidUpdate = function (nextProps) {
+  const {
+    userAddress: oldAddress,
+  } = this.props
+  const {
+    userAddress: newAddress,
+  } = nextProps
+
+  if (!oldAddress || !newAddress) return
+  if (oldAddress === newAddress) return
+
+  this.setState({ isLoading: true })
+  this.createFreshTokenTracker()
+}
+
+TokenBalance.prototype.updateBalance = function (tokens = []) {
+  const [{ string }] = tokens
+  this.setState({
+    balance: string,
+    isLoading: false,
+  })
+}
+
+TokenBalance.prototype.componentWillUnmount = function () {
+  if (!this.tracker) return
+  this.tracker.stop()
+}
+

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -13,23 +13,34 @@ function TokenCell () {
 
 TokenCell.prototype.render = function () {
   const props = this.props
-  const { address, symbol, string, network, userAddress } = props
+  const {
+    address,
+    symbol,
+    string,
+    network,
+    // userAddress,
+  } = props
 
   return (
-    h('li.token-cell', {
+    h('div.token-list-item', {
       style: { cursor: network === '1' ? 'pointer' : 'default' },
-      onClick: this.view.bind(this, address, userAddress, network),
+      // onClick: this.view.bind(this, address, userAddress, network),
     }, [
 
       h(Identicon, {
-        diameter: 50,
+        className: 'token-list-item__identicon',
+        diameter: 45,
         address,
         network,
       }),
 
-      h('h3', `${string || 0} ${symbol}`),
+      h('h.token-list-item__balance-wrapper', null, [
+        h('h3.token-list-item__token-balance', `${string || 0} ${symbol}`),
 
-      h('span', { style: { flex: '1 0 auto' } }),
+        h('div.token-list-item__fiat-amount', {
+          style: {},
+        }, '210 FPO'),
+      ]),
 
       /*
       h('button', {

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -42,7 +42,7 @@ TokenCell.prototype.render = function () {
 
   return (
     h('div.token-list-item', {
-      className: `token-list-item ${selectedTokenAddress ? 'token-list-item--active' : ''}`,
+      className: `token-list-item ${selectedTokenAddress === address ? 'token-list-item--active' : ''}`,
       // style: { cursor: network === '1' ? 'pointer' : 'default' },
       // onClick: this.view.bind(this, address, userAddress, network),
       onClick: () => setSelectedToken(address),

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -1,10 +1,27 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const connect = require('react-redux').connect
 const Identicon = require('./identicon')
 const prefixForNetwork = require('../../lib/etherscan-prefix-for-network')
+const selectors = require('../selectors')
+const actions = require('../actions')
 
-module.exports = TokenCell
+function mapStateToProps (state) {
+  return {
+    network: state.metamask.network,
+    selectedTokenAddress: state.metamask.selectedTokenAddress,
+    userAddress: selectors.getSelectedAddress(state),
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    setSelectedToken: address => dispatch(actions.setSelectedToken(address)),
+  }
+}
+
+module.exports = connect(mapStateToProps, mapDispatchToProps)(TokenCell)
 
 inherits(TokenCell, Component)
 function TokenCell () {
@@ -18,13 +35,17 @@ TokenCell.prototype.render = function () {
     symbol,
     string,
     network,
+    setSelectedToken,
+    selectedTokenAddress,
     // userAddress,
   } = props
 
   return (
     h('div.token-list-item', {
-      style: { cursor: network === '1' ? 'pointer' : 'default' },
+      className: `token-list-item ${selectedTokenAddress ? 'token-list-item--active' : ''}`,
+      // style: { cursor: network === '1' ? 'pointer' : 'default' },
       // onClick: this.view.bind(this, address, userAddress, network),
+      onClick: () => setSelectedToken(address),
     }, [
 
       h(Identicon, {

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -58,9 +58,9 @@ TokenCell.prototype.render = function () {
       h('h.token-list-item__balance-wrapper', null, [
         h('h3.token-list-item__token-balance', `${string || 0} ${symbol}`),
 
-        h('div.token-list-item__fiat-amount', {
-          style: {},
-        }, '210 FPO'),
+        // h('div.token-list-item__fiat-amount', {
+        //   style: {},
+        // }, '210 FPO'),
       ]),
 
       /*

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -8,7 +8,6 @@ const connect = require('react-redux').connect
 const selectors = require('../selectors')
 
 function mapStateToProps (state) {
-
   return {
     network: state.metamask.network,
     tokens: state.metamask.tokens,
@@ -42,7 +41,6 @@ function TokenList () {
 TokenList.prototype.render = function () {
   const state = this.state
   const { tokens, isLoading, error } = state
-  const { userAddress, network } = this.props
 
   if (isLoading) {
     return this.message('Loading Tokens...')
@@ -53,13 +51,7 @@ TokenList.prototype.render = function () {
     return this.message('There was a problem loading your token balances.')
   }
 
-  const tokenViews = tokens.map((tokenData) => {
-    tokenData.network = network
-    tokenData.userAddress = userAddress
-    return h(TokenCell, tokenData)
-  })
-
-  return h('div', tokenViews)
+  return h('div', tokens.map((tokenData) => h(TokenCell, tokenData)))
 }
 
 TokenList.prototype.message = function (body) {

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -45,7 +45,7 @@ TokenList.prototype.render = function () {
   const { userAddress, network } = this.props
 
   if (isLoading) {
-    return this.message('Loading')
+    return this.message('Loading Tokens...')
   }
 
   if (error) {
@@ -115,22 +115,29 @@ TokenList.prototype.createFreshTokenTracker = function () {
   })
 }
 
-TokenList.prototype.componentWillUpdate = function (nextProps) {
-  if (nextProps.network === 'loading') return
-  const oldNet = this.props.network
-  const newNet = nextProps.network
+TokenList.prototype.componentDidUpdate = function (nextProps) {
+  const {
+    network: oldNet,
+    userAddress: oldAddress,
+  } = this.props
+  const {
+    network: newNet,
+    userAddress: newAddress,
+  } = nextProps
 
-  if (oldNet && newNet && newNet !== oldNet) {
-    this.setState({ isLoading: true })
-    this.createFreshTokenTracker()
-  }
+  if (newNet === 'loading') return
+  if (!oldNet || !newNet || !oldAddress || !newAddress) return
+  if (oldAddress === newAddress && oldNet === newNet) return
+
+  this.setState({ isLoading: true })
+  this.createFreshTokenTracker()
 }
 
 TokenList.prototype.updateBalances = function (tokens) {
-  // const heldTokens = tokens.filter(token => {
-  //   return token.balance !== '0' && token.string !== '0.000'
-  // })
-  this.setState({ tokens: tokens, isLoading: false })
+  const heldTokens = tokens.filter(token => {
+    return token.balance !== '0' && token.string !== '0.000'
+  })
+  this.setState({ tokens: heldTokens, isLoading: false })
 }
 
 TokenList.prototype.componentWillUnmount = function () {

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -1,0 +1,92 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const Identicon = require('./identicon')
+
+module.exports = TxListItem
+
+inherits(TxListItem, Component)
+function TxListItem () {
+  Component.call(this)
+}
+
+TxListItem.prototype.getAddressText = function (address) {
+  return address
+    ? `${address.slice(0, 10)}...${address.slice(-4)}`
+    : 'Contract Published'
+}
+
+TxListItem.prototype.render = function () {
+  const {
+    transactionStatus,
+    onClick,
+    transActionId,
+    dateString,
+    address,
+    transactionAmount,
+    className
+  } = this.props
+
+  return h(`div${className || ''}`, {
+    key: transActionId,
+    onClick: () => onClick && onClick(transActionId),
+  }, [
+    h(`div.flex-column.tx-list-item-wrapper`, {}, [
+
+      h('div.tx-list-date-wrapper', {
+        style: {},
+      }, [
+        h('span.tx-list-date', {}, [
+          dateString,
+        ]),
+      ]),
+
+      h('div.flex-row.tx-list-content-wrapper', {
+        style: {},
+      }, [
+
+        h('div.tx-list-identicon-wrapper', {
+          style: {},
+        }, [
+          h(Identicon, {
+            address,
+            diameter: 28,
+          }),
+        ]),
+
+        h('div.tx-list-account-and-status-wrapper', {}, [
+          h('div.tx-list-account-wrapper', {
+            style: {},
+          }, [
+            h('span.tx-list-account', {}, [
+              this.getAddressText(address),
+            ]),
+          ]),
+
+          h('div.tx-list-status-wrapper', {
+            style: {},
+          }, [
+            h('span.tx-list-status', {}, [
+              transactionStatus,
+            ]),
+          ]),
+        ]),
+
+        h('div.flex-column.tx-list-details-wrapper', {
+          style: {},
+        }, [
+
+          h('span.tx-list-value', {}, [
+            transactionAmount,
+          ]),
+
+          h('span.tx-list-fiat-value', {}, [
+            '+ $300 USD',
+          ]),
+
+        ]),
+      ]),
+    ]) // holding on icon from design
+  ])
+}
+

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -1,6 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const prefixForNetwork = require('../../lib/etherscan-prefix-for-network')
 const Identicon = require('./identicon')
 
 module.exports = TxListItem
@@ -24,7 +25,7 @@ TxListItem.prototype.render = function () {
     dateString,
     address,
     transactionAmount,
-    className
+    className,
   } = this.props
 
   return h(`div${className || ''}`, {
@@ -89,4 +90,3 @@ TxListItem.prototype.render = function () {
     ]) // holding on icon from design
   ])
 }
-

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -3,7 +3,7 @@ const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const selectors = require('../selectors')
-const Identicon = require('./identicon')
+const TxListItem = require('./tx-list-item')
 const { formatBalance, formatDate } = require('../util')
 const { showConfTxPage } = require('../actions')
 
@@ -53,16 +53,6 @@ TxList.prototype.render = function () {
   ])
 }
 
-TxList.prototype.getAddressText = function (transaction) {
-  const {
-    txParams: { to },
-  } = transaction
-
-  return to
-    ? `${to.slice(0, 10)}...${to.slice(-4)}`
-    : 'Contract Published'
-}
-
 TxList.prototype.renderTranstions = function () {
   const { txsToRender } = this.props
 
@@ -92,70 +82,21 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
   } = props
   const { showConfTxPage } = this.props
 
-  return h('div.tx-list-item', {
-    key: transaction.id,
-  }, [
-    h('div.flex-column.tx-list-item__wrapper', {
-      onClick: () => transactionStatus === 'unapproved' && showConfTxPage({id: transActionId}),
-      style: {},
-    }, [
+  if (!address) return null
+    
+  const opts = {
+    transactionStatus,
+    transActionId,
+    dateString,
+    address,
+    transactionAmount,
+  }
 
-      h('div.tx-list-date-wrapper', {
-        style: {},
-      }, [
-        h('span.tx-list-date', {}, [
-          dateString,
-        ]),
-      ]),
+  if (transactionStatus === 'unapproved') {
+    opts.onClick = () => showConfTxPage({id: transActionId})
+    opts.className = '.tx-list-pending-item-container'
+  }
 
-      h('div.flex-row.tx-list-content-wrapper', {
-        style: {},
-      }, [
-
-        h('div.tx-list-identicon-wrapper', {
-          style: {},
-        }, [
-          h(Identicon, {
-            address,
-            diameter: 28,
-          }),
-        ]),
-
-        h('div.tx-list-account-and-status-wrapper', {}, [
-          h('div.tx-list-account-wrapper', {
-            style: {},
-          }, [
-            h('span.tx-list-account', {}, [
-              this.getAddressText(transaction),
-            ]),
-          ]),
-
-          h('div.tx-list-status-wrapper', {
-            style: {},
-          }, [
-            h('span.tx-list-status', {}, [
-              transactionStatus,
-            ]),
-          ]),
-        ]),
-
-        h('div.flex-column.tx-list-details-wrapper', {
-          style: {},
-        }, [
-
-          h('span.tx-list-value', {}, [
-            transactionAmount,
-          ]),
-
-          h('span.tx-list-fiat-value', {}, [
-            '+ $300 USD',
-          ]),
-
-        ]),
-
-      ]),
-    ]),
-
-  ])
+  return h(TxListItem, opts)
 }
 

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -65,11 +65,13 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
     transactionAmount: formatBalance(transaction.txParams.value, 6),
   }
   const {
-    address = '',
+    address,
     transactionStatus,
     transactionAmount,
     dateString,
   } = props
+
+  if (!address) return null
 
   return h('div', {
     key: transaction.id,

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -102,6 +102,7 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
   if (transactionStatus === 'unapproved') {
     opts.onClick = () => showConfTxPage({id: transActionId})
     opts.className += '.tx-list-pending-item-container'
+    opt.transactionStatus = 'Not Started'
   }
   else if (transactionHash) {
     opts.onClick = () => this.view(transactionHash, transactionNetworkId)

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -40,7 +40,7 @@ TxList.prototype.render = function () {
       }, [
 
         h('div', {
-          style: {}
+          style: {},
         }, 'transactions'),
 
       ]),
@@ -64,45 +64,52 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
     transactionStatus: transaction.status,
     transactionAmount: formatBalance(transaction.txParams.value, 6),
   }
-  const { address, transactionStatus, transactionAmount, dateString } = props
+  const {
+    address = '',
+    transactionStatus,
+    transactionAmount,
+    dateString,
+  } = props
 
-  return h('div', {}, [
+  return h('div', {
+    key: transaction.id,
+  }, [
     h('div.flex-column.tx-list-item-wrapper', {
-      style: {}
+      style: {},
     }, [
 
       h('div.tx-list-date-wrapper', {
-        style: {}
+        style: {},
       }, [
         h('span.tx-list-date', {}, [
           dateString,
-        ])
+        ]),
       ]),
 
       h('div.flex-row.tx-list-content-wrapper', {
-        style: {}
+        style: {},
       }, [
 
         h('div.tx-list-identicon-wrapper', {
-          style: {}
+          style: {},
         }, [
           h(Identicon, {
             address,
             diameter: 28,
-          })
+          }),
         ]),
 
         h('div.tx-list-account-and-status-wrapper', {}, [
           h('div.tx-list-account-wrapper', {
-            style: {}
+            style: {},
           }, [
             h('span.tx-list-account', {}, [
-              `${address.slice(0, 10)}...${address.slice(-4)}`
+              `${address.slice(0, 10)}...${address.slice(-4)}`,
             ]),
           ]),
 
           h('div.tx-list-status-wrapper', {
-            style: {}
+            style: {},
           }, [
             h('span.tx-list-status', {}, [
               transactionStatus,
@@ -111,7 +118,7 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
         ]),
 
         h('div.flex-column.tx-list-details-wrapper', {
-          style: {}
+          style: {},
         }, [
 
           h('span.tx-list-value', {}, [
@@ -126,7 +133,7 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
 
       ]),
     ]),
-    contentDivider
+    contentDivider,
 
   ])
 }

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -20,14 +20,9 @@ function TxList () {
   Component.call(this)
 }
 
-const contentDivider = h('div.tx-list-content-divider', {
-  style: {},
-})
-
 TxList.prototype.render = function () {
 
-  const { txsToRender } = this.props
-  console.log('transactions to render', txsToRender)
+  // console.log('transactions to render', txsToRender)
 
   return h('div.flex-column.tx-list-container', {}, [
 
@@ -46,13 +41,29 @@ TxList.prototype.render = function () {
 
     ]),
 
-    contentDivider,
-
-    txsToRender.map((transaction) => {
-      return this.renderTransactionListItem(transaction)
-    }),
+    this.renderTranstions(),
 
   ])
+}
+
+TxList.prototype.getAddressText = function (transaction) {
+  const {
+    txParams: { to },
+  } = transaction
+
+  return to
+    ? `${to.slice(0, 10)}...${to.slice(-4)}`
+    : 'Contract Published'
+}
+
+TxList.prototype.renderTranstions = function () {
+  const { txsToRender } = this.props
+
+  return txsToRender.length
+    ? txsToRender.map((transaction) => {
+      return this.renderTransactionListItem(transaction)
+    })
+    : h('div.tx-list-item.tx-list-item--empty', [ 'No Transactions' ])
 }
 
 // TODO: Consider moving TxListItem into a separate component
@@ -70,12 +81,10 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
     dateString,
   } = props
 
-  if (!address) return null
-
-  return h('div', {
+  return h('div.tx-list-item', {
     key: transaction.id,
   }, [
-    h('div.flex-column.tx-list-item-wrapper', {
+    h('div.flex-column.tx-list-item__wrapper', {
       style: {},
     }, [
 
@@ -105,7 +114,7 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
             style: {},
           }, [
             h('span.tx-list-account', {}, [
-              `${address.slice(0, 10)}...${address.slice(-4)}`,
+              this.getAddressText(transaction),
             ]),
           ]),
 
@@ -134,7 +143,6 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
 
       ]),
     ]),
-    contentDivider,
 
   ])
 }

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -27,7 +27,6 @@ const contentDivider = h('div.tx-list-content-divider', {
 TxList.prototype.render = function () {
 
   const { txsToRender } = this.props
-
   console.log('transactions to render', txsToRender)
 
   return h('div.flex-column.tx-list-container', {}, [

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -5,13 +5,20 @@ const inherits = require('util').inherits
 const selectors = require('../selectors')
 const Identicon = require('./identicon')
 const { formatBalance, formatDate } = require('../util')
+const { showConfTxPage } = require('../actions')
 
-module.exports = connect(mapStateToProps)(TxList)
+module.exports = connect(mapStateToProps, mapDispatchToProps)(TxList)
 
 function mapStateToProps (state) {
   return {
     txsToRender: selectors.transactionsSelector(state),
     conversionRate: selectors.conversionRateSelector(state),
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    showConfTxPage: ({ id }) => dispatch(showConfTxPage({ id }))
   }
 }
 
@@ -22,7 +29,7 @@ function TxList () {
 
 TxList.prototype.render = function () {
 
-  // console.log('transactions to render', txsToRender)
+  const { txsToRender, showConfTxPage } = this.props
 
   return h('div.flex-column.tx-list-container', {}, [
 
@@ -73,18 +80,23 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
     address: transaction.txParams.to,
     transactionStatus: transaction.status,
     transactionAmount: formatBalance(transaction.txParams.value, 6),
+    transActionId: transaction.id,
   }
+
   const {
     address,
     transactionStatus,
     transactionAmount,
     dateString,
+    transActionId,
   } = props
+  const { showConfTxPage } = this.props
 
   return h('div.tx-list-item', {
     key: transaction.id,
   }, [
     h('div.flex-column.tx-list-item__wrapper', {
+      onClick: () => transactionStatus === 'unapproved' && showConfTxPage({id: transActionId}),
       style: {},
     }, [
 

--- a/ui/app/components/tx-view.js
+++ b/ui/app/components/tx-view.js
@@ -9,7 +9,6 @@ const selectors = require('../selectors')
 const BalanceComponent = require('./balance-component')
 const TxList = require('./tx-list')
 const Identicon = require('./identicon')
-const TokenBalance = require('./token-balance')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(TxView)
 
@@ -18,11 +17,11 @@ function mapStateToProps (state) {
 
   const identities = state.metamask.identities
   const accounts = state.metamask.accounts
+  const network = state.metamask.network
   const selectedTokenAddress = state.metamask.selectedTokenAddress
   const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
   const checksumAddress = selectedAddress && ethUtil.toChecksumAddress(selectedAddress)
   const identity = identities[selectedAddress]
-  const account = accounts[selectedAddress]
 
   return {
     sidebarOpen,
@@ -31,7 +30,7 @@ function mapStateToProps (state) {
     selectedTokenAddress,
     selectedToken: selectors.getSelectedToken(state),
     identity,
-    account,
+    network,
   }
 }
 
@@ -50,40 +49,55 @@ function TxView () {
 }
 
 TxView.prototype.renderHeroBalance = function () {
-  const {account, selectedToken, showModal, showSendPage } = this.props
+  const { selectedToken } = this.props
 
   return h('div.hero-balance', {}, [
 
-    h(BalanceComponent, {
-      balanceValue: account && account.balance,
-      token: selectedToken,
-    }),
+    h(BalanceComponent, { token: selectedToken }),
 
-    h('div.flex-row.flex-center.hero-balance-buttons', {}, [
-      h('button.btn-clear', {
-        style: {
-          textAlign: 'center',
-        },
-        onClick: () => showModal({
-          name: 'BUY',
-        }),
-      }, 'BUY'),
-
-      h('button.btn-clear', {
-        style: {
-          textAlign: 'center',
-          marginLeft: '0.8em',
-        },
-        onClick: showSendPage,
-      }, 'SEND'),
-
-    ]),
+    this.renderButtons(),
   ])
 }
 
-TxView.prototype.render = function () {
+TxView.prototype.renderButtons = function () {
+  const {selectedToken, showModal, showSendPage } = this.props
 
-  const { selectedAddress, identity } = this.props
+  return !selectedToken
+    ? (
+      h('div.flex-row.flex-center.hero-balance-buttons', [
+        h('button.btn-clear', {
+          style: {
+            textAlign: 'center',
+          },
+          onClick: () => showModal({
+            name: 'BUY',
+          }),
+        }, 'BUY'),
+
+        h('button.btn-clear', {
+          style: {
+            textAlign: 'center',
+            marginLeft: '0.8em',
+          },
+          onClick: showSendPage,
+        }, 'SEND'),
+      ])
+    )
+    : (
+      h('div.flex-row.flex-center.hero-balance-buttons', [
+        h('button.btn-clear', {
+          style: {
+            textAlign: 'center',
+            marginLeft: '0.8em',
+          },
+          onClick: showSendPage,
+        }, 'SEND'),
+      ])
+    )
+}
+
+TxView.prototype.render = function () {
+  const { selectedAddress, identity, network } = this.props
 
   return h('div.tx-view.flex-column', {
     style: {},
@@ -113,6 +127,7 @@ TxView.prototype.render = function () {
         h(Identicon, {
           diameter: 24,
           address: selectedAddress,
+          network,
         }),
       ]),
 

--- a/ui/app/components/tx-view.js
+++ b/ui/app/components/tx-view.js
@@ -4,10 +4,12 @@ const h = require('react-hyperscript')
 const ethUtil = require('ethereumjs-util')
 const inherits = require('util').inherits
 const actions = require('../actions')
+const selectors = require('../selectors')
 
 const BalanceComponent = require('./balance-component')
 const TxList = require('./tx-list')
 const Identicon = require('./identicon')
+const TokenBalance = require('./token-balance')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(TxView)
 
@@ -16,6 +18,7 @@ function mapStateToProps (state) {
 
   const identities = state.metamask.identities
   const accounts = state.metamask.accounts
+  const selectedTokenAddress = state.metamask.selectedTokenAddress
   const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
   const checksumAddress = selectedAddress && ethUtil.toChecksumAddress(selectedAddress)
   const identity = identities[selectedAddress]
@@ -25,6 +28,8 @@ function mapStateToProps (state) {
     sidebarOpen,
     selectedAddress,
     checksumAddress,
+    selectedTokenAddress,
+    selectedToken: selectors.getSelectedToken(state),
     identity,
     account,
   }
@@ -44,9 +49,41 @@ function TxView () {
   Component.call(this)
 }
 
+TxView.prototype.renderHeroBalance = function () {
+  const {account, selectedToken, showModal, showSendPage } = this.props
+
+  return h('div.hero-balance', {}, [
+
+    h(BalanceComponent, {
+      balanceValue: account && account.balance,
+      token: selectedToken,
+    }),
+
+    h('div.flex-row.flex-center.hero-balance-buttons', {}, [
+      h('button.btn-clear', {
+        style: {
+          textAlign: 'center',
+        },
+        onClick: () => showModal({
+          name: 'BUY',
+        }),
+      }, 'BUY'),
+
+      h('button.btn-clear', {
+        style: {
+          textAlign: 'center',
+          marginLeft: '0.8em',
+        },
+        onClick: showSendPage,
+      }, 'SEND'),
+
+    ]),
+  ])
+}
+
 TxView.prototype.render = function () {
 
-  const { selectedAddress, identity, account } = this.props
+  const { selectedAddress, identity } = this.props
 
   return h('div.tx-view.flex-column', {
     style: {},
@@ -87,41 +124,7 @@ TxView.prototype.render = function () {
 
     ]),
 
-    h('div.hero-balance', {
-      style: {},
-    }, [
-
-      h(BalanceComponent, {
-        balanceValue: account && account.balance,
-        style: {},
-      }),
-
-      h('div.flex-row.flex-center.hero-balance-buttons', {
-        style: {},
-      }, [
-        h('button.btn-clear', {
-          style: {
-            textAlign: 'center',
-          },
-          onClick: () => {
-            this.props.showModal({
-              name: 'BUY',
-            })
-          },
-        }, 'BUY'),
-
-        h('button.btn-clear', {
-          style: {
-            textAlign: 'center',
-            marginLeft: '0.8em',
-          },
-          onClick: () => {
-            this.props.showSendPage()
-          },
-        }, 'SEND'),
-
-      ]),
-    ]),
+    this.renderHeroBalance(),
 
     h(TxList, {}),
 

--- a/ui/app/components/tx-view.js
+++ b/ui/app/components/tx-view.js
@@ -40,6 +40,7 @@ function mapDispatchToProps (dispatch) {
     hideSidebar: () => { dispatch(actions.hideSidebar()) },
     showModal: (payload) => { dispatch(actions.showModal(payload)) },
     showSendPage: () => { dispatch(actions.showSendPage()) },
+    showSendTokenPage: () => { dispatch(actions.showSendTokenPage()) },
   }
 }
 
@@ -60,7 +61,7 @@ TxView.prototype.renderHeroBalance = function () {
 }
 
 TxView.prototype.renderButtons = function () {
-  const {selectedToken, showModal, showSendPage } = this.props
+  const {selectedToken, showModal, showSendPage, showSendTokenPage } = this.props
 
   return !selectedToken
     ? (
@@ -90,7 +91,7 @@ TxView.prototype.renderButtons = function () {
             textAlign: 'center',
             marginLeft: '0.8em',
           },
-          onClick: showSendPage,
+          onClick: showSendTokenPage,
         }, 'SEND'),
       ])
     )

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -6,6 +6,7 @@ const Identicon = require('./identicon')
 const AccountDropdowns = require('./dropdowns/index.js').AccountDropdowns
 const actions = require('../actions')
 const BalanceComponent = require('./balance-component')
+const TokenList = require('./token-list')
 const selectors = require('../selectors')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(WalletView)
@@ -17,6 +18,7 @@ function mapStateToProps (state) {
     sidebarOpen: state.appState.sidebarOpen,
     identities: state.metamask.identities,
     accounts: state.metamask.accounts,
+    tokens: state.metamask.tokens,
     selectedAddress: selectors.getSelectedAddress(state),
     selectedIdentity: selectors.getSelectedIdentity(state),
     selectedAccount: selectors.getSelectedAccount(state),
@@ -35,8 +37,23 @@ function WalletView () {
   Component.call(this)
 }
 
+WalletView.prototype.renderTokenBalances = function () {
+  // const { tokens = [] } = this.props
+  // return tokens.map(({ address, decimals, symbol }) => (
+  //   h(BalanceComponent, {
+  //     balanceValue: 0,
+  //     style: {},
+  //   })
+  // ))
+  return h(TokenList)
+}
+
 WalletView.prototype.render = function () {
-  const { network, responsiveDisplayClassname, identities, selectedAddress, selectedAccount, accounts, selectedIdentity } = this.props
+  const {
+    network, responsiveDisplayClassname, identities,
+    selectedAddress, selectedAccount, accounts,
+    selectedIdentity,
+  } = this.props
   // temporary logs + fake extra wallets
   console.log('walletview, selectedAccount:', selectedAccount)
 
@@ -134,7 +151,10 @@ WalletView.prototype.render = function () {
 
         ]),
 
+
     ]),
+
+    this.renderTokenBalances(),
 
   ])
 }

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -49,7 +49,7 @@ WalletView.prototype.renderWalletBalance = function () {
   return h('div', { className }, [
     h('div.wallet-balance',
       {
-        onClick: () => unsetSelectedToken(),
+        onClick: unsetSelectedToken,
       },
       [
         h(BalanceComponent, {

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -22,6 +22,7 @@ function mapStateToProps (state) {
     selectedAddress: selectors.getSelectedAddress(state),
     selectedIdentity: selectors.getSelectedIdentity(state),
     selectedAccount: selectors.getSelectedAccount(state),
+    selectedTokenAddress: state.metamask.selectedTokenAddress,
   }
 }
 
@@ -29,6 +30,7 @@ function mapDispatchToProps (dispatch) {
   return {
     showSendPage: () => { dispatch(actions.showSendPage()) },
     hideSidebar: () => { dispatch(actions.hideSidebar()) },
+    unsetSelectedToken: () => dispatch(actions.setSelectedToken()),
   }
 }
 
@@ -37,15 +39,26 @@ function WalletView () {
   Component.call(this)
 }
 
-WalletView.prototype.renderTokenBalances = function () {
-  // const { tokens = [] } = this.props
-  // return tokens.map(({ address, decimals, symbol }) => (
-  //   h(BalanceComponent, {
-  //     balanceValue: 0,
-  //     style: {},
-  //   })
-  // ))
-  return h(TokenList)
+WalletView.prototype.renderWalletBalance = function () {
+  const { selectedTokenAddress, selectedAccount, unsetSelectedToken } = this.props
+  const selectedClass = selectedTokenAddress
+    ? ''
+    : 'wallet-balance-wrapper--active'
+  const className = `flex-column wallet-balance-wrapper ${selectedClass}`
+
+  return h('div', { className }, [
+    h('div.wallet-balance',
+      {
+        onClick: () => unsetSelectedToken(),
+      },
+      [
+        h(BalanceComponent, {
+          balanceValue: selectedAccount.balance,
+          style: {},
+        }),
+      ]
+    ),
+  ])
 }
 
 WalletView.prototype.render = function () {
@@ -139,22 +152,9 @@ WalletView.prototype.render = function () {
       ]),
     ]),
 
-    // Wallet Balances
-    h('div.flex-column.wallet-balance-wrapper.wallet-balance-wrapper-active', {}, [
+    this.renderWalletBalance(),
 
-        h('div.wallet-balance', {}, [
-
-          h(BalanceComponent, {
-            balanceValue: selectedAccount.balance,
-            style: {},
-          }),
-
-        ]),
-
-
-    ]),
-
-    this.renderTokenBalances(),
+    h(TokenList),
 
   ])
 }

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -64,11 +64,11 @@ WalletView.prototype.renderWalletBalance = function () {
 WalletView.prototype.render = function () {
   const {
     network, responsiveDisplayClassname, identities,
-    selectedAddress, selectedAccount, accounts,
+    selectedAddress, accounts,
     selectedIdentity,
   } = this.props
   // temporary logs + fake extra wallets
-  console.log('walletview, selectedAccount:', selectedAccount)
+  // console.log('walletview, selectedAccount:', selectedAccount)
 
   return h('div.wallet-view.flex-column' + (responsiveDisplayClassname || ''), {
     style: {},

--- a/ui/app/css/itcss/components/index.scss
+++ b/ui/app/css/itcss/components/index.scss
@@ -23,3 +23,5 @@
 @import './transaction-list.scss';
 
 @import './sections.scss';
+
+@import './token-list.scss';

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -6,13 +6,6 @@
 $tx-view-bg: $white;
 $wallet-view-bg: $wild-sand;
 
-html {
-
-  @media screen and (max-width: 575px) {
-    height: 500px;
-  }
-}
-
 // Main container
 .main-container {
   position: absolute;

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -6,6 +6,13 @@
 $tx-view-bg: $white;
 $wallet-view-bg: $wild-sand;
 
+html {
+
+  @media screen and (max-width: 575px) {
+    height: 500px;
+  }
+}
+
 // Main container
 .main-container {
   position: absolute;
@@ -17,7 +24,7 @@ $wallet-view-bg: $wild-sand;
 }
 
 .main-container::-webkit-scrollbar {
-  display: none; 
+  display: none;
 }
 
 // tx view
@@ -37,6 +44,7 @@ $wallet-view-bg: $wild-sand;
 
   @media screen and (min-width: 576px) {
     overflow-y: scroll;
+    overflow-x: hidden;
   }
 
   .wallet-view-account-details {
@@ -142,7 +150,10 @@ $wallet-view-bg: $wild-sand;
 
   .main-container {
     margin-top: 35px;
+    height: calc(100% - 34px);
     width: 100%;
+    overflow-y: auto;
+    background-color: $white;
   }
 
   button.btn-clear {

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -203,3 +203,44 @@
   font-size: .8em;
   padding: 1px 4px;
 }
+
+.send-token {
+  width: 498px;
+  height: 605px;
+  background-color: #fff;
+  display: flex;
+  flex-flow: column nowrap;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .08);
+  padding: 46px 40.5px 26px;
+  position: relative;
+  top: -26px;
+  z-index: 25;
+  align-items: center;
+  font-family: "Montserrat Light";
+
+  .identicon {
+    position: absolute;
+    top: -35px;
+    z-index: 25;
+  }
+
+  &__title {
+    color: $scorpion;
+    font-size: 20px;
+    line-height: 29px;
+  }
+
+  &__description,
+  &__balance-text,
+  &__token-symbol {
+    margin-top: 10px;
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  &__token-balance {
+    font-size: 43px;
+    line-height: 40px;
+    margin-top: 13px;
+  }
+}

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -226,7 +226,7 @@
 
   &__title {
     color: $scorpion;
-    font-size: 20px;
+    font-size: 18px;
     line-height: 29px;
   }
 
@@ -234,12 +234,12 @@
   &__balance-text,
   &__token-symbol {
     margin-top: 10px;
-    font-size: 16px;
+    font-size: 14px;
     line-height: 24px;
   }
 
   &__token-balance {
-    font-size: 43px;
+    font-size: 40px;
     line-height: 40px;
     margin-top: 13px;
   }

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -10,6 +10,23 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   transition: linear 200ms;
   background-color: rgba($wallet-balance-bg, 0);
 
+  &__token-balance {
+    font-size: 130%;
+
+    @media #{$wallet-balance-breakpoint-range} {
+      font-size: 105%;
+    }
+  }
+
+  &__fiat-amount {
+    margin-top: .25%;
+    font-size: 105%;
+
+    @media #{$wallet-balance-breakpoint-range} {
+      font-size: 95%;
+    }
+  }
+
   @media #{$wallet-balance-breakpoint-range} {
     padding: 10% 4%;
   }
@@ -21,14 +38,9 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   &__identicon {
     margin-right: 15px;
     border: '1px solid #dedede';
-  }
 
-  &__token-balance {
-    font-size: 130%;
-  }
-
-  &__fiat-amount {
-    margin-top: .25%;
-    font-size: 105%;
+    @media #{$wallet-balance-breakpoint-range} {
+      margin-right: 4%;
+    }
   }
 }

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -1,9 +1,22 @@
+$wallet-balance-breakpoint: 890px;
+$wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (max-width: #{$wallet-balance-breakpoint})";
+
 .token-list-item {
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
   padding: 20px 24px;
   cursor: pointer;
+  transition: linear 200ms;
+  background-color: rgba($wallet-balance-bg, 0);
+
+  @media #{$wallet-balance-breakpoint-range} {
+    padding: 10% 4%;
+  }
+
+  &--active {
+    background-color: rgba($wallet-balance-bg, 1);
+  }
 
   &__identicon {
     margin-right: 15px;

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -1,0 +1,21 @@
+.token-list-item {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  padding: 20px 24px;
+  cursor: pointer;
+
+  &__identicon {
+    margin-right: 15px;
+    border: '1px solid #dedede';
+  }
+
+  &__token-balance {
+    font-size: 130%;
+  }
+
+  &__fiat-amount {
+    margin-top: .25%;
+    font-size: 105%;
+  }
+}

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -61,14 +61,6 @@
   flex: 0 0 70px;
   align-items: stretch;
   justify-content: flex-start;
-
-  @media screen and (max-width: $break-small) {
-    margin: 0 1.3em .95em;
-  }
-
-  @media screen and (min-width: $break-large) {
-    margin: 0 2.37em;
-  }
 }
 
 .tx-list-date-wrapper {
@@ -93,11 +85,13 @@
 .tx-list-date {
   color: $dusty-gray;
   font-size: 12px;
+  font-family: "Montserrat UltraLight";
 }
 
 .tx-list-identicon-wrapper {
   align-self: center;
-  flex: 0.5 1 auto;
+  flex: 0 0 auto;
+  margin-right: 16px;
 }
 
 .tx-list-account-and-status-wrapper {
@@ -118,6 +112,7 @@
 
     .tx-list-account-wrapper {
       flex: 1.3 2 auto;
+      min-width: 153px;
     }
 
     .tx-list-status-wrapper {
@@ -137,18 +132,41 @@
   }
 }
 
-.tx-list-details-wrapper {
-  align-self: center;
-  flex: 2 2 auto;
-  color: $dusty-gray;
+.tx-list-item {
+  border-top: 1px solid rgb(231, 231, 231);
 
-  .tx-list-value {
-    font-size: 16px;
-    text-align: right;
+  @media screen and (max-width: $break-small) {
+    margin: 0 1.3em .95em;
   }
 
-  .tx-list-fiat-value {
-    font-size: 12px;
-    text-align: right;
+  @media screen and (min-width: $break-large) {
+    margin: 0 2.37em;
+  }
+
+  &:last-of-type {
+    border-bottom: 1px solid rgb(231, 231, 231);
+    margin-bottom: 32px;
+  }
+
+  &__wrapper {
+    align-self: center;
+    flex: 2 2 auto;
+    color: $dusty-gray;
+
+    .tx-list-value {
+      font-size: 16px;
+      text-align: right;
+    }
+
+    .tx-list-fiat-value {
+      font-size: 12px;
+      text-align: right;
+    }
+  }
+
+  &--empty {
+    text-align: center;
+    border-bottom: none !important;
+    padding: 16px;
   }
 }

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -73,10 +73,10 @@
 
 .tx-list-pending-item-container {
   cursor: pointer;
-}
 
-.tx-list-pending-item-container:hover {
-  background: $alto;
+  &:hover {
+    background: rgba($alto, .2);
+  }
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -71,12 +71,17 @@
   }
 }
 
-.tx-list-pending-item-container {
+.tx-list-clickable {
   cursor: pointer;
 
   &:hover {
     background: rgba($alto, .2);
   }
+}
+
+.tx-list-pending-item-container {
+  cursor: pointer;
+  opacity: 0.5;
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -61,6 +61,22 @@
   flex: 0 0 70px;
   align-items: stretch;
   justify-content: flex-start;
+
+  @media screen and (max-width: $break-small) {
+    padding: 0 1.3em .95em;
+  }
+
+  @media screen and (min-width: $break-large) {
+    margin: 0 2.37em;
+  }
+}
+
+.tx-list-pending-item-container {
+  cursor: pointer;
+}
+
+.tx-list-pending-item-container:hover {
+  background: $alto;
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/css/itcss/components/wallet-balance.scss
+++ b/ui/app/css/itcss/components/wallet-balance.scss
@@ -3,7 +3,7 @@ $wallet-balance-breakpoint: 890px;
 $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (max-width: #{$wallet-balance-breakpoint})";
 
 .wallet-balance-wrapper {
-  flex: 0 0 80px;
+  flex: 0 0 auto;
 }
 
 .wallet-balance {
@@ -12,6 +12,8 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
+  flex: 0 0 auto;
+  cursor: pointer;
 
   .balance-container {
     display: flex;

--- a/ui/app/css/itcss/components/wallet-balance.scss
+++ b/ui/app/css/itcss/components/wallet-balance.scss
@@ -4,6 +4,12 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
 
 .wallet-balance-wrapper {
   flex: 0 0 auto;
+  transition: linear 200ms;
+  background: rgba($wallet-balance-bg, 0);
+
+  &--active {
+    background: rgba($wallet-balance-bg, 1);
+  }
 }
 
 .wallet-balance {
@@ -61,8 +67,4 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     height: 45px;
     border: 1px solid $alto;
   }
-}
-
-.wallet-balance-wrapper-active {
-  background: $wallet-balance-bg;
 }

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -219,6 +219,16 @@ function reduceApp (state, action) {
         warning: null,
       })
 
+    case actions.SHOW_SEND_TOKEN_PAGE:
+      return extend(appState, {
+        currentView: {
+          name: 'sendToken',
+          context: appState.currentView.context,
+        },
+        transForward: true,
+        warning: null,
+      })
+
     case actions.SHOW_NEW_KEYCHAIN:
       return extend(appState, {
         currentView: {

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -14,10 +14,6 @@ function reduceApp (state, action) {
   if (selectedAddress) {
     name = 'accountDetail'
   }
-  if (hasUnconfActions) {
-    log.debug('pending txs detected, defaulting to conf-tx view.')
-    name = 'confTx'
-  }
 
   var defaultView = {
     name,

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -360,7 +360,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: action.id && indexForPending(state, action.id) || 0,
+          context: action.id ? indexForPending(state, action.id) : 0,
         },
         transForward: action.transForward,
         warning: null,

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -360,7 +360,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: 0,
+          context: action.id && indexForPending(state, action.id) || 0,
         },
         transForward: action.transForward,
         warning: null,

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -17,6 +17,7 @@ function reduceMetamask (state, action) {
     lastUnreadNotice: undefined,
     frequentRpcList: [],
     addressBook: [],
+    selectedTokenAddress: null,
   }, state.metamask)
 
   switch (action.type) {
@@ -114,6 +115,11 @@ function reduceMetamask (state, action) {
       })
       delete newState.seedWords
       return newState
+
+    case actions.SET_SELECTED_TOKEN:
+      return extend(metamaskState, {
+        selectedTokenAddress: action.value,
+      })
 
     case actions.SAVE_ACCOUNT_LABEL:
       const account = action.value.account

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -45,11 +45,16 @@ function conversionRateSelector (state) {
 }
 
 function transactionsSelector (state) {
-  const { network } = state.metamask
+  const { network, selectedTokenAddress } = state.metamask
   const unapprovedMsgs = valuesFor(state.metamask.unapprovedMsgs)
   const shapeShiftTxList = (network === '1') ? state.metamask.shapeShiftTxList : undefined
   const transactions = state.metamask.selectedAddressTxList || []
   const txsToRender = !shapeShiftTxList ? transactions.concat(unapprovedMsgs) : transactions.concat(unapprovedMsgs, shapeShiftTxList)
 
-  return txsToRender.sort((a, b) => b.time - a.time)
+  return selectedTokenAddress
+    ? txsToRender
+      .filter(({ to }) => to === selectedTokenAddress)
+      .sort((a, b) => b.time - a.time)
+    : txsToRender
+      .sort((a, b) => b.time - a.time)
 }

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -4,6 +4,7 @@ const selectors = {
   getSelectedAddress,
   getSelectedIdentity,
   getSelectedAccount,
+  getSelectedToken,
   conversionRateSelector,
   transactionsSelector,
 }
@@ -29,6 +30,14 @@ function getSelectedAccount (state) {
   const selectedAddress = getSelectedAddress(state)
 
   return accounts[selectedAddress]
+}
+
+function getSelectedToken (state) {
+  const tokens = state.metamask.tokens || []
+  const selectedTokenAddress = state.metamask.selectedTokenAddress
+  const selectedToken = tokens.filter(({ address }) => address === selectedTokenAddress)[0]
+
+  return selectedToken || null
 }
 
 function conversionRateSelector (state) {

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -193,20 +193,19 @@ SendTransactionScreen.prototype.render = function () {
 
           h('datalist#addresses', {}, [
             // Corresponds to the addresses owned.
-            Object.keys(props.identities).map((key) => {
-              const identity = props.identities[key]
+            Object.entries(props.identities).map(([key, { address, name }]) => {
               return h('option', {
-                value: identity.address,
-                label: identity.name,
-                key: identity.address,
+                value: address,
+                label: name,
+                key: address,
               })
             }),
             // Corresponds to previously sent-to addresses.
-            props.addressBook.map((identity) => {
+            props.addressBook.map(({ address, name }) => {
               return h('option', {
-                value: identity.address,
-                label: identity.name,
-                key: identity.address,
+                value: address,
+                label: name,
+                key: address,
               })
             }),
           ]),

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -69,7 +69,7 @@ function SendTransactionScreen () {
       from: '',
       to: '',
       // these values are hardcoded, so "Next" can be clicked
-      amount: '0.0001', // see L544
+      amount: '0x0', // see L544
       gasPrice: '0x5d21dba00',
       gas: '0x7b0d',
       txData: null,
@@ -98,6 +98,7 @@ SendTransactionScreen.prototype.render = function () {
     conversionRate,
     currentCurrency,
   } = props
+
   const { blockGasLimit, newTx } = this.state
   const { gas, gasPrice } = newTx
 
@@ -141,16 +142,14 @@ SendTransactionScreen.prototype.render = function () {
           h('input.large-input.send-screen-input', {
             list: 'accounts',
             placeholder: 'Account',
-            value: this.state.from,
+            value: this.state.newTx.from,
             onChange: (event) => {
               console.log('event', event.target.value)
               this.setState({
-                newTx: Object.assign(
-                  this.state.newTx,
-                  {
-                    from: event.target.value,
-                  }
-                ),
+                newTx: {
+                  ...this.state.newTx,
+                  from: event.target.value,
+                },
               })
             },
           }, [
@@ -175,24 +174,61 @@ SendTransactionScreen.prototype.render = function () {
             'To:',
           ]),
 
-          h(EnsInput, {
+          h('input.large-input.send-screen-input', {
             name: 'address',
-            placeholder: 'Recipient Address',
-            onChange: () => {
+            list: 'addresses',
+            placeholder: 'Address',
+            value: this.state.newTx.to,
+            onChange: (event) => {
               console.log('event', event.target.value)
               this.setState({
-                newTx: Object.assign(
-                  this.state.newTx,
-                  {
-                    to: event.target.value,
-                  }
-                ),
+                newTx: {
+                  ...this.state.newTx,
+                  to: event.target.value,
+                },
               })
             },
-            network,
-            identities,
-            addressBook,
-          }),
+          }, [
+          ]),
+
+          h('datalist#addresses', {}, [
+            // Corresponds to the addresses owned.
+            Object.keys(props.identities).map((key) => {
+              const identity = props.identities[key]
+              return h('option', {
+                value: identity.address,
+                label: identity.name,
+                key: identity.address,
+              })
+            }),
+            // Corresponds to previously sent-to addresses.
+            props.addressBook.map((identity) => {
+              return h('option', {
+                value: identity.address,
+                label: identity.name,
+                key: identity.address,
+              })
+            }),
+          ]),
+
+          // h(EnsInput, {
+          //   name: 'address',
+          //   placeholder: 'Recipient Address',
+          //   value: this.state.newTx.to,
+          //   onChange: (event) => {
+          //     this.setState({
+          //       newTx: Object.assign(
+          //         this.state.newTx,
+          //         {
+          //           to: event.target.value,
+          //         }
+          //       ),
+          //     })
+          //   },
+          //   network,
+          //   identities,
+          //   addressBook,
+          // }),
 
         ]),
 
@@ -209,7 +245,7 @@ SendTransactionScreen.prototype.render = function () {
           h('input.large-input.send-screen-input', {
             placeholder: '0 ETH',
             type: 'number',
-            onChange: () => {
+            onChange: (event) => {
               this.setState({
                 newTx: Object.assign(
                   this.state.newTx,
@@ -631,23 +667,15 @@ SendTransactionScreen.prototype.onSubmit = function () {
 
   this.props.dispatch(addToAddressBook(recipient, nickname))
 
-  // var txParams = {
-  //   // from: this.props.address,
-  //   from: this.state.newTx.to,
-
-  //   // value: '0x' + value.toString(16),
-  //   value: '0x38d7ea4c68000', // hardcoded
-
-  //   // New: gas will now be specified on this step
-  //   gas: this.state.newTx.gas,
-  //   gasPrice: this.state.newTx.gasPrice
-  // }
-
-  // Hardcoded
   var txParams = {
-    from: '0x82df11beb942beeed58d466fcb0f0791365c7684',
-    to: '0xa43126b621db5b4fd98f959d9e5499f655913d34',
-    value: '0x0',
+    from: this.state.newTx.from,
+    to: this.state.newTx.to,
+
+    value: this.state.newTx.amount.toString(16),
+
+    // New: gas will now be specified on this step
+    gas: this.state.newTx.gas,
+    gasPrice: this.state.newTx.gasPrice
   }
 
   if (recipient) txParams.to = addHexPrefix(recipient)

--- a/ui/index.js
+++ b/ui/index.js
@@ -36,12 +36,6 @@ function startApp (metamaskState, accountManager, opts) {
     networkVersion: opts.networkVersion,
   })
 
-  // if unconfirmed txs, start on txConf page
-  const unapprovedTxsAll = txHelper(metamaskState.unapprovedTxs, metamaskState.unapprovedMsgs, metamaskState.unapprovedPersonalMsgs, metamaskState.network)
-  if (unapprovedTxsAll.length > 0) {
-    store.dispatch(actions.showConfTxPage())
-  }
-
   accountManager.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })

--- a/ui/lib/icon-factory.js
+++ b/ui/lib/icon-factory.js
@@ -53,7 +53,7 @@ function imageElFor (address) {
   const path = `images/contract/${fileName}`
   const img = document.createElement('img')
   img.src = path
-  img.style.width = '75%'
+  img.style.width = '100%'
   return img
 }
 


### PR DESCRIPTION
This PR does the following:
- removes the code that automatically brings the user to the confirm page if there are any pending transactions
- creates a "tx-list-item" component to be used for rendering the transactions in the main list
- creates a link to the confirm page from pending transactions on the main list.
- Makes a design change here to help the user understand and navigate the clicking of pending transactions to get to the confirm page. See the below screenshot:

<img width="1280" alt="screen shot 2017-08-31 at 12 06 29 am" src="https://user-images.githubusercontent.com/7499938/29904113-d9710656-8de1-11e7-9dac-cbf519f00bdd.png">
